### PR TITLE
Remove dependency on hardcoded notification->factory map from the lib

### DIFF
--- a/lib/__mocks__/MockNotification.ts
+++ b/lib/__mocks__/MockNotification.ts
@@ -17,18 +17,19 @@ export class MockNotification
   extends AbstractNotification
   implements IMockNotification
 {
-  private static __type = "MockNotification";
-  private constructor(
-    public readonly uid: string,
-    public readonly type: string = MockNotification.__type,
-    public readonly ownerUid: string,
-    public readonly senderUid: string,
-    public readonly isRead: boolean,
-    public readonly payload: Record<string, any>,
-    public readonly createdAt: number,
-    public readonly customField: string
-  ) {
-    super();
+  private static readonly __type = "MockNotification";
+
+  public readonly uid: string;
+  public readonly type = MockNotification.__type;
+  public readonly ownerUid: string;
+  public readonly senderUid: string;
+  public readonly isRead: boolean;
+  public readonly createdAt: number;
+  public readonly payload: Record<string, any>;
+  public readonly customField: string;
+
+  constructor(data: IMockNotification) {
+    super(data);
   }
 
   static new(
@@ -36,29 +37,39 @@ export class MockNotification
     senderUid: string,
     customField: string = "foo"
   ): MockNotification {
-    return new MockNotification(
-      v4(),
-      MockNotification.__type,
+    return new MockNotification({
+      uid: v4(),
+      type: MockNotification.__type,
       ownerUid,
       senderUid,
-      false,
-      {},
-      Date.now(),
-      customField
-    );
+      isRead: false,
+      createdAt: Date.now(),
+      payload: {},
+      customField,
+    });
   }
 
   static fromJson(json: Record<string, any>): MockNotification {
-    return new MockNotification(
-      json.uid,
-      json.type,
-      json.ownerUid,
-      json.senderUid,
-      json.isRead,
-      json.payload,
-      json.createdAt,
-      json.customField
-    );
+    const {
+      uid,
+      type,
+      ownerUid,
+      senderUid,
+      isRead,
+      createdAt,
+      payload,
+      customField,
+    } = json;
+    return new MockNotification({
+      uid,
+      type,
+      ownerUid,
+      senderUid,
+      isRead,
+      createdAt,
+      payload,
+      customField,
+    });
   }
 
   toINotification(): IMockNotification {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,6 +11,12 @@ import { RepositoryFactory } from "./repositories/repositoryFactory";
 import { NotificationService } from "./services/notification.service";
 import { UserNotificationMetadataService } from "./services/userNotificationMetadata.service";
 
+import { NotificationServiceBuilder } from "./services/notification.service.builder";
+import {
+  AbstractNotification,
+  ConcreteClass,
+} from "./models/abstractNotification";
+
 export interface INotificationFramework {
   getNotificationServiceX: (viewerId: string) => NotificationService;
   getUserNotificationMetadataServiceX: (
@@ -35,7 +41,10 @@ export class NotificationFramework implements INotificationFramework {
 
   private constructor(
     private readonly dbConfig: IDatabaseConfig,
-    private readonly logger: ILogger = new Logger()
+    private readonly logger: ILogger = new Logger(),
+    private readonly notificationClasess: Readonly<
+      Array<ConcreteClass<AbstractNotification<string>>>
+    >
   ) {
     try {
       verifyDatabaseConfig(dbConfig);
@@ -47,10 +56,17 @@ export class NotificationFramework implements INotificationFramework {
 
   static getInstanceX = (
     dbConfig: IDatabaseConfig,
-    logger: ILogger
+    logger: ILogger,
+    notificationClasses: Readonly<
+      Array<ConcreteClass<AbstractNotification<string>>>
+    >
   ): NotificationFramework => {
     if (!this.instance) {
-      this.instance = new NotificationFramework(dbConfig, logger);
+      this.instance = new NotificationFramework(
+        dbConfig,
+        logger,
+        notificationClasses
+      );
       const { notificationRepository, userNotificationMetadataRepository } =
         RepositoryFactory.getRepositoryX(dbConfig);
       this.instance.notificationRepository = notificationRepository;
@@ -79,6 +95,7 @@ export class NotificationFramework implements INotificationFramework {
         viewerId,
         this.notificationRepository,
         this.userNotificationMetadataRepository,
+        this.notificationClasess,
         this.logger
       );
     } catch (error) {
@@ -111,4 +128,10 @@ export class NotificationFramework implements INotificationFramework {
 }
 
 export default NotificationFramework;
-export { Errors, DatabaseType };
+export {
+  Errors,
+  DatabaseType,
+  NotificationServiceBuilder,
+  NotificationService,
+  UserNotificationMetadataService,
+};

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -5,7 +5,6 @@ export interface ILogger {
   error(message: any, ...optionalParams: any[]): void;
 }
 
-// TODO(Taman): instantiate this class in the entry point of the framework.
 export class Logger implements ILogger {
   constructor() {}
   warn(message: any, ...optionalParams: any[]): void {

--- a/lib/models/abstractNotification.ts
+++ b/lib/models/abstractNotification.ts
@@ -11,18 +11,30 @@ export interface INotification<T = string> {
 export abstract class AbstractNotification<T = string>
   implements INotification<T>
 {
-  public abstract uid: string;
-  public abstract type: T;
-  public abstract ownerUid: string;
-  public abstract senderUid: string;
-  public abstract isRead: boolean;
-  public abstract createdAt: number;
-  public abstract payload: Record<string, any>;
+  public readonly uid: string;
+  public readonly type: T;
+  public readonly ownerUid: string;
+  public readonly senderUid: string;
+  public readonly isRead: boolean;
+  public readonly createdAt: number;
+  public readonly payload: Record<string, any>;
+
+  constructor(data: INotification<T>) {
+    Object.assign(this, data);
+  }
 
   public abstract genResponse(): Promise<INotificationResponse | null>;
   public abstract toINotification(): INotification<T>;
+
+  static fromJson(_json: Record<string, any>): AbstractNotification {
+    throw new Error("Method not implemented. Implement in subclass.");
+  }
 }
 
 export interface INotificationResponse {
   notification: INotification & Record<string, any>;
 }
+
+export type ConcreteClass<T extends AbstractNotification<string>> = new (
+  ...args: any[]
+) => T;

--- a/lib/models/notificationFactory.ts
+++ b/lib/models/notificationFactory.ts
@@ -1,0 +1,20 @@
+import {
+  AbstractNotification,
+  type ConcreteClass,
+} from "./abstractNotification";
+
+export const notificationFactory = <T extends AbstractNotification<string>>(
+  json: Readonly<Record<string, any>>,
+  classes: Readonly<Array<ConcreteClass<T>>>
+): T => {
+  const className = json.type;
+  const matchingClass = classes.find((cls) => cls.name === className);
+
+  if (!matchingClass) {
+    throw new Error(`Unknown class type: ${className}`);
+  }
+
+  const instance = new matchingClass(json);
+
+  return instance;
+};

--- a/lib/notificationFramework.builder.ts
+++ b/lib/notificationFramework.builder.ts
@@ -3,10 +3,17 @@ import { DatabaseType, IDatabaseConfig } from "./configs/db/database.config";
 import { IInMemoryConfig } from "./configs/db/inMemory.config";
 import { IMongoCollectionConfig } from "./configs/db/mongoCollection.config";
 import { ILogger, Logger } from "./logger";
+import type {
+  AbstractNotification,
+  ConcreteClass,
+} from "./models/abstractNotification";
 
 export class NotificationFrameworkBuilder {
   private logger: ILogger;
   private dbConfig: IDatabaseConfig;
+  private concreteNotificationClasses: Array<
+    ConcreteClass<AbstractNotification<string>>
+  >;
 
   public withLogger(logger: ILogger): NotificationFrameworkBuilder {
     this.logger = logger;
@@ -33,6 +40,15 @@ export class NotificationFrameworkBuilder {
     return this;
   }
 
+  public withConcreteNotificationClasses(
+    concreteNotificationClasses: Array<
+      ConcreteClass<AbstractNotification<string>>
+    >
+  ): NotificationFrameworkBuilder {
+    this.concreteNotificationClasses = concreteNotificationClasses;
+    return this;
+  }
+
   public buildX = (): NotificationFramework => {
     if (!this.logger) {
       this.logger = new Logger();
@@ -41,6 +57,10 @@ export class NotificationFrameworkBuilder {
       throw new Error("dbConfig is required");
     }
 
-    return NotificationFramework.getInstanceX(this.dbConfig, this.logger);
+    return NotificationFramework.getInstanceX(
+      this.dbConfig,
+      this.logger,
+      this.concreteNotificationClasses
+    );
   };
 }

--- a/lib/services/__tests__/notification.service.test.ts
+++ b/lib/services/__tests__/notification.service.test.ts
@@ -36,12 +36,14 @@ describe("NotificationService", () => {
       viewerId,
       notificationRepository,
       notificationUserMetdataRepository,
+      [MockNotification],
       new Logger()
     );
     ownersNotificationService = new NotificationService(
       ownerId,
       notificationRepository,
       notificationUserMetdataRepository,
+      [MockNotification],
       new Logger()
     );
 
@@ -60,8 +62,9 @@ describe("NotificationService", () => {
   });
 
   it("shouldn't mark a notification as read when user doesn't have permission", async () => {
+    // Test for sender
     try {
-      await ownersNotificationService.genMarkAsReadX(notif.uid);
+      await sendersNotificationService.genMarkAsReadX(notif.uid);
       const fetchedNotification = await notificationRepository.genFetchX(
         notif.uid
       );
@@ -74,10 +77,10 @@ describe("NotificationService", () => {
   it("should mark a notification as read when user has permission", async () => {
     // Test for owner
     await ownersNotificationService.genMarkAsReadX(notif.uid);
-    const fetchedNotificationOwner = await notificationRepository.genFetchX(
+    const fetchedNotification = await notificationRepository.genFetchX(
       notif.uid
     );
-    expect(fetchedNotificationOwner?.isRead).toBe(true);
+    expect(fetchedNotification?.isRead).toBe(true);
   });
 
   test("sender can't  delete a notification", async () => {

--- a/lib/services/__tests__/userNotificationMetadata.service.test.ts
+++ b/lib/services/__tests__/userNotificationMetadata.service.test.ts
@@ -27,12 +27,14 @@ describe("UserNotificationMetadataService", () => {
       viewerId,
       notificationRepository,
       notificationUserMetdataRepository,
+      [MockNotification], // enabled concrete notification classes
       new Logger()
     );
     ownersNotificationService = new NotificationService(
       ownerId,
       notificationRepository,
       notificationUserMetdataRepository,
+      [MockNotification], // enabled concrete notification classes
       new Logger()
     );
     // Mock console.error to prevent error logs from appearing in the console

--- a/lib/services/notification.service.builder.ts
+++ b/lib/services/notification.service.builder.ts
@@ -1,0 +1,61 @@
+import { Logger, type ILogger } from "../logger";
+import {
+  AbstractNotification,
+  type ConcreteClass,
+} from "../models/abstractNotification";
+import { INotificationRepository } from "../repositories/INotificationRepository";
+import type { IUserNotificationMetadataRepository } from "../repositories/IUserNotificationMetadataRepository";
+import { NotificationService } from "./notification.service";
+
+export class NotificationServiceBuilder {
+  private viewerId: string;
+  private notificationRepository: INotificationRepository;
+  private userNotificationMetadataRepository: IUserNotificationMetadataRepository;
+  private logger: ILogger;
+  private notificationClasses: Array<
+    ConcreteClass<AbstractNotification<string>>
+  >;
+  constructor() {}
+
+  withViewerId(viewerId: string): NotificationServiceBuilder {
+    this.viewerId = viewerId;
+    return this;
+  }
+
+  withNotificationRepository(
+    notificationRepository: INotificationRepository
+  ): NotificationServiceBuilder {
+    this.notificationRepository = notificationRepository;
+    return this;
+  }
+
+  withUserNotificationMetadataRepository(
+    userNotificationMetadataRepository: IUserNotificationMetadataRepository
+  ): NotificationServiceBuilder {
+    this.userNotificationMetadataRepository =
+      userNotificationMetadataRepository;
+    return this;
+  }
+
+  withLogger(logger: ILogger): NotificationServiceBuilder {
+    this.logger = logger;
+    return this;
+  }
+
+  withNotificationClasses(
+    notificationClasses: Array<ConcreteClass<AbstractNotification<string>>>
+  ): NotificationServiceBuilder {
+    this.notificationClasses = notificationClasses;
+    return this;
+  }
+
+  build() {
+    return new NotificationService(
+      this.viewerId,
+      this.notificationRepository,
+      this.userNotificationMetadataRepository,
+      this.notificationClasses,
+      this.logger ?? new Logger()
+    );
+  }
+}

--- a/lib/services/notification.service.ts
+++ b/lib/services/notification.service.ts
@@ -24,7 +24,7 @@ export class NotificationService {
     public readonly viewerId: string,
     public readonly notificationRepository: INotificationRepository,
     public readonly userNotificationMetadataRepository: IUserNotificationMetadataRepository,
-    private readonly notificationClasses: Readonly<
+    public readonly notificationClasses: Readonly<
       Array<ConcreteClass<AbstractNotification<string>>>
     >,
     public readonly logger: ILogger = new Logger()

--- a/lib/services/notification.service.ts
+++ b/lib/services/notification.service.ts
@@ -1,6 +1,7 @@
-import type { ILogger } from "../logger";
+import { Logger, type ILogger } from "../logger";
 import {
   AbstractNotification,
+  ConcreteClass,
   INotification,
   INotificationResponse,
 } from "../models/abstractNotification";
@@ -8,19 +9,13 @@ import { NotificationPerm } from "../notificaionPerm";
 import { INotificationRepository } from "../repositories/INotificationRepository";
 import { UserNotificationMetadataService } from "./userNotificationMetadata.service";
 
-import { MockNotification } from "../__mocks__/MockNotification";
 import { UserPermissionError } from "../errors/userPermissionError";
+import { notificationFactory } from "../models/notificationFactory";
 import { IUserNotificationMetadataRepository } from "../repositories/IUserNotificationMetadataRepository";
 
-const notificationFactoryMap: {
+export interface INotificationFactoryMap {
   [key: string]: (json: Object) => AbstractNotification;
-} = {
-  // NotificationTypes -> NotificationClass.
-  // This is a map of all the notification types to their respective classes.
-  // This is used to instantiate the correct class when fetching notifications from the database.
-  // For example, if the type of the notification is "A", the factory method will return an instance of ANotification.
-  MockNotification: (json: Object) => MockNotification.fromJson(json),
-};
+}
 
 export class NotificationService {
   private userNotificationMetadataService: UserNotificationMetadataService;
@@ -29,7 +24,10 @@ export class NotificationService {
     public readonly viewerId: string,
     public readonly notificationRepository: INotificationRepository,
     public readonly userNotificationMetadataRepository: IUserNotificationMetadataRepository,
-    public readonly logger: ILogger
+    private readonly notificationClasses: Readonly<
+      Array<ConcreteClass<AbstractNotification<string>>>
+    >,
+    public readonly logger: ILogger = new Logger()
   ) {
     this.userNotificationMetadataService = new UserNotificationMetadataService(
       viewerId,
@@ -38,22 +36,7 @@ export class NotificationService {
     );
   }
 
-  factory = (
-    rawNotification: Record<string, any>
-  ): AbstractNotification | null => {
-    const notificationType = rawNotification["type"] as string;
-    const factoryMethod = notificationFactoryMap[notificationType];
-    if (!factoryMethod) {
-      this.logger.error(
-        `No factory method found for notification type ${notificationType}`
-      );
-      return null;
-    } else {
-      return factoryMethod(rawNotification);
-    }
-  };
-
-  private genFetchAllForUserX = async (): Promise<INotification[]> => {
+  private genFetchAllForUserX = async (): Promise<AbstractNotification[]> => {
     const rawNotifications =
       await this.notificationRepository.genFetchAllRawForViewerX(this.viewerId);
     // intentinally running async
@@ -61,10 +44,13 @@ export class NotificationService {
     return (
       await Promise.all(
         rawNotifications.map((rawNotification: Object) =>
-          this.factory(rawNotification as INotification)
+          notificationFactory(
+            rawNotification as AbstractNotification,
+            this.notificationClasses
+          )
         )
       )
-    ).filter((notif) => notif != null) as INotification[];
+    ).filter((notif) => notif != null) as AbstractNotification[];
   };
 
   genFetchAllResponseForUserX = async (): Promise<INotificationResponse[]> => {
@@ -146,7 +132,9 @@ export class NotificationService {
       }
       const maybeNotification =
         maybeNotification__PRIVACY_UNSAFE as INotification;
-      return maybeNotification ? this.factory(maybeNotification) : null;
+      return maybeNotification
+        ? notificationFactory(maybeNotification, this.notificationClasses)
+        : null;
     } catch (error) {
       this.logger.error(
         `Error fetching notification for user ${this.viewerId}: ${error.message}`


### PR DESCRIPTION
### Problem

Previously, we relied on a hardcoded variable in the `lib/notification.service` file to instantiate concrete notification classes from JSON. This approach required developers to modify the `lib` directory, which was acceptable for the Jhotika codebase but is not ideal for the OSS version. We want to ensure that users of the framework can avoid modifying files in the `lib` directory.

### Solution

1. Introduced a configurable factory class.
2. Enabled the framework instance and `NotificationService` class to accept a list of concrete classes, allowing flexibility without modifying core files.

### Caveat

This solution introduces significantly more lines of code and isn't as clean as I would like. Feedback and PRs are welcome!